### PR TITLE
Enable the basic variation schema

### DIFF
--- a/plugins/variations/index.tsx
+++ b/plugins/variations/index.tsx
@@ -1,0 +1,84 @@
+import { defineArrayMember, defineField, definePlugin, DocumentDefinition, FieldDefinition, SchemaTypeDefinition } from "sanity";
+
+// enables autocompletion and validation of document options
+declare module 'sanity' {
+    export interface DocumentOptions {
+        enableVariations?: string[]
+    }
+}
+
+/**
+ * Check if we are looking at a document schema type (and not an object or primitive)
+ */
+const isDocument = (def: SchemaTypeDefinition): def is DocumentDefinition => def.type === 'document'
+
+/**
+ * Return a list of allowed variable fields.
+ */
+function filterVariableFields(fields: FieldDefinition[], variableFieldNames: string[]) {
+    return fields.filter(field => variableFieldNames.includes(field.name))
+}
+
+/**
+ * Given a document schema, add the variations field.
+ */
+function augmentSchema(type: DocumentDefinition): DocumentDefinition {
+    const variableFieldNames = type.options.enableVariations
+
+    return {
+        ...type,
+        fields: [
+            ...type.fields,
+            defineField({
+                type: 'array' as const,
+                name: 'variations',
+                of: [
+                    defineArrayMember({
+                        type: 'object',
+                        name: 'variation',
+                        fields: [
+                            defineField({
+                                type: 'string' as const,
+                                name: 'variationId',
+                                title: 'Variation ID',
+                                validation: (rule) => rule.required()
+                            }),
+                            ...filterVariableFields(type.fields, variableFieldNames)
+                        ],
+                        preview: {
+                            select: {
+                                title: variableFieldNames[0],
+                                subtitle: 'variationId'
+                            }
+                        }
+                    })
+                ]
+            })
+        ]
+    }
+}
+
+/**
+ * Given all the types registered in the schema, add the variation field to those that are opted in
+ * TODO: also define and hoist the variation object shape for each enabled type, to support GraphQL
+ * TODO: consider making the variation opt-in and configuration at the plugin configuration object instead of the schema type's options object
+ */
+function buildTypes(types: SchemaTypeDefinition[]) {
+    return types.map((def) => {
+        if (isDocument(def) && def.options?.enableVariations) {
+            return augmentSchema(def)
+        }
+        return def
+    })
+}
+
+/**
+ * Sanity Studio plugin to add a variations field to document types where variations are enabled
+ */
+export default definePlugin(() => {
+    return {
+        schema: {
+            types: buildTypes
+        }
+    }
+})

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -2,19 +2,20 @@
  * This config is used to set up Sanity Studio that's mounted on the `/pages/studio/[[...index]].tsx` route
  */
 
+import { scheduledPublishing } from '@sanity/scheduled-publishing'
 import { visionTool } from '@sanity/vision'
+import { theme } from 'https://themer.sanity.build/api/hues?preset=tw-cyan&primary=b595f9'
 import { defineConfig, definePlugin } from 'sanity'
 import { deskTool } from 'sanity/desk'
 import { unsplashImageAsset } from 'sanity-plugin-asset-source-unsplash'
 import DocumentsPane from 'sanity-plugin-documents-pane'
-import { scheduledPublishing } from '@sanity/scheduled-publishing'
-import { theme } from 'https://themer.sanity.build/api/hues?preset=tw-cyan&primary=b595f9'
 import { workflow } from 'sanity-plugin-workflow'
 
-import { schemaTypes } from './schemas'
 import { mediaConfigPlugin, structure } from './plugins/config'
-import newsletterPlugin from './plugins/newsletter'
 import defaultDocumentNode from './plugins/config/defaultDocumentNode'
+import newsletterPlugin from './plugins/newsletter'
+import variations from './plugins/variations'
+import { schemaTypes } from './schemas'
 
 // @TODO: update next-sanity/studio to automatically set this when needed
 const basePath = '/studio/tech'
@@ -43,6 +44,7 @@ const defaultConfig = (type: string) => {
       workflow({
         schemaTypes: ['article'],
       }),
+      variations()
     ],
   })()
 }

--- a/schemas/article.ts
+++ b/schemas/article.ts
@@ -49,6 +49,9 @@ export default defineType({
     { type: 'seo', name: 'seo', title: 'SEO' },
     { type: 'brand', name: 'brand' },
   ],
+  options: {
+    enableVariations: ['title', 'mainImage']
+  },
   preview: {
     select: {
       title: 'title',


### PR DESCRIPTION
Adds a plugin to add variation fields to a document.
Enables this plugin for the article document type.

![image](https://user-images.githubusercontent.com/10197537/203855355-86090637-7aac-4ea8-9061-3f7ee9fdd79d.png)
